### PR TITLE
ntp.conf: restrict line must be with IP and not with fqdn

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,6 +6,8 @@
 # Author:: Tim Smith (<tsmith@limelight.com>)
 # Author:: Charles Johnson (<charles@opscode.com>)
 #
+# Contributor: Kévin Maziere (<kevin@kbrwadventure.com>)
+#
 # Copyright 2009-2013, Opscode, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +24,7 @@
 #
 
 # default attributes for all platforms
-default['ntp']['servers']   = [] # The default recipe sets a list of common NTP servers (COOK-1170)
+default['ntp']['servers']   = [""] # The default recipe sets a list of common NTP servers (COOK-1170)
 default['ntp']['peers'] = []
 default['ntp']['restrictions'] = []
 
@@ -44,6 +46,8 @@ default['ntp']['listen'] = nil
 default['ntp']['listen_network'] = nil
 default['ntp']['apparmor_enabled'] = false
 default['ntp']['monitor'] = false
+default['ntp']['restrict_default'] = ""
+#default['ntp']['restrict_default'] = "restrict default ignore" #Warning if set you must set all Ip of peers/servers with their own restrict line into ntp.conf file
 
 # overrides on a platform-by-platform basis
 case node['platform_family']

--- a/templates/default/ntp.conf.erb
+++ b/templates/default/ntp.conf.erb
@@ -30,7 +30,9 @@ enable monitor
 <% else -%>
 disable monitor
 <% end -%>
-
+<% if !node['ntp']['restrict_default'].empty? -%>
+<%= node['ntp']['restrict_default'] %>
+<% end -%>
 <%# If ntp.peers is not empty %>
 <% unless node['ntp']['peers'].empty? -%>
 <%   node['ntp']['peers'].each do |ntppeer| -%>
@@ -45,12 +47,19 @@ disable monitor
 <%# Whether this is a client or server, we want upstream servers. %>
 <%# We should guard the servers array against deep merge. %>
 <%# This should keep authoritative local servers from being included twice. %>
-<% ( node['ntp']['servers'] - node['ntp']['peers'] ).each do |ntpserver| -%>
+<% @records4.each do |record| %>
 <%#   Loop through defined servers, but don't try to upstream ourself %>
-<%   if node['ipaddress'] != ntpserver and node['fqdn'] != ntpserver -%>
-<%  -%>server <%= ntpserver %> iburst
-<%  -%>restrict <%= ntpserver %> nomodify notrap noquery
-<%   end -%>
+<%    if node['ipaddress'] != record[:ip] and node['fqdn'] != record[:fqdn] -%>
+<%   -%>server <%= record[:fqdn] %> iburst
+<%   -%>restrict <%= record[:ip] %> nomodify notrap noquery
+<%    end -%>
+<% end -%>
+<% @records6.each do |record| %>
+<%#   Loop through defined servers, but don't try to upstream ourself %>
+<%    if node['ipaddress'] != record[:ip] and node['fqdn'] != record[:fqdn] -%>
+<%   -%>server <%= record[:fqdn] %> iburst
+<%   -%>restrict <%= record[:ip] %> nomodify notrap noquery
+<%    end -%>
 <% end -%>
 
 restrict default kod notrap nomodify nopeer noquery


### PR DESCRIPTION
Hi

restrict line with ip do not restrict anything.
http://support.ntp.org/bin/view/Support/AccessRestrictions#Section_6.5.1.2.1.
" You may use either a hostname or IP address on the server line. You must use an IP address on the restrict line. There is no harm in adding the restrictions shown in brackets but keep in mind that if you are accepting time from someone it may be considered courteous to allow them to see a bit of information about their client."

So I've patched the recipe to autogenerate IP from given server name.
Working for ipv4/ipv6 address.

