### PR TITLE
For apparmor, create local subdir and ntp stub file.

### DIFF
--- a/recipes/apparmor.rb
+++ b/recipes/apparmor.rb
@@ -21,6 +21,22 @@ service 'apparmor' do
   action :nothing
 end
 
+directory '/etc/apparmor.d/local/' do
+  owner 'root'
+  group 'root'
+  mode '0755'
+  not_if { ::File.directory?('/etc/apparmor.d/local/') }
+end
+
+cookbook_file '/etc/apparmor.d/local/usr.sbin.ntpd' do
+  source 'local/usr.sbin.ntpd'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  not_if { ::File.exists?('/etc/apparmor.d/local/usr.sbin.ntpd') }
+  notifies :restart, 'service[apparmor]'
+end
+
 cookbook_file '/etc/apparmor.d/usr.sbin.ntpd' do
   source 'usr.sbin.ntpd.apparmor'
   owner 'root'


### PR DESCRIPTION
Recipe assumes /etc/apparmor.d/local/, but ubuntu 10.04 (LTS, still supported) does not use this, and the recipe fails.

This patch uses directory and cookbook_file with not_if guards to create the directory and position an empty local/usr.sbin.ntp file, if they don't already exist.

Patched cookbook has been successfully tested against 10.04 and 14.04.
