### PR TITLE
Move high stratum real CMOs configuration to an overridable attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ Attributes
     platform is apparmor enabled by default, (currently Ubuntu)
     default will be true.
 
+* `ntp['use_cmos']`
+  - Boolean, uses a high stratum undisciplined clock for machines with real CMOS clock.
+  - Defaults to true unless a platform appears to be virtualized according to Ohai.
+
 
 Usage
 -----

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -83,3 +83,11 @@ when 'solaris2'
   default['ntp']['var_group'] = 'sys'
   default['ntp']['leapfile'] = '/etc/inet/ntp.leap'
 end
+
+unless node['platform'] == 'windows'
+  if not node['virtualization'] or node['virtualization']['role'] != 'guest'
+    default['ntp']['use_cmos'] = true
+  else
+    default['ntp']['use_cmos'] = false
+  end
+end

--- a/templates/default/ntp.conf.erb
+++ b/templates/default/ntp.conf.erb
@@ -69,9 +69,7 @@ restrict -6 ::1 nomodify
 
 <%# It is best practice to use a high stratum undisciplined clock, if you have a real CMOS clock %>
 <%# Except cases where you have a low stratum server, or a virtualized system without a real CMOS clock %>
-<% unless node['platform'] == 'windows' -%>
-<%   if not node['virtualization'] or node['virtualization']['role'] != 'guest' -%>
+<% if node['ntp']['use_cmos'] -%>
 <%  -%>server  127.127.1.0 # local clock
 <%  -%>fudge   127.127.1.0 stratum 10
-<%   end -%>
 <% end -%>


### PR DESCRIPTION
Made this change due to an Ohai bug I came across with Fedora 19/20 hosts misreporting their virtualization status.

ohai virtualization on Fedora 19 reported:
```
mjuarez@foo ~$ ohai virtualization
{
  "system": "lxc",
  "role": "host"
}
```

Whereas ohai virtualization on Ubuntu 14.04 would report:
```
ubuntu@foo:~$ ohai virtualization
[
  [
    "system",
    "xen"
  ],
  [
    "role",
    "guest"
  ]
]
```

All of these hosts were within EC2 and I definitely didn't want to use high stratum.

This pull request moves the logic from template to the attributes to allow it to be overridden if so desired.