### PR TITLE
Provide an attribute for setting noquery for localhost lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ Attributes
 * `ntp['server']['maxpoll']` (applies to NTP Servers and Clients)
   - Boolean. Defaults to 10 (ntp default). Specify the maximum poll intervals for NTP messages, in seconds to the power of two.
 
+* `ntp['localhost']['noquery']` (applies to NTP Servers and Clients)
+  - Boolean. Defaults to false. Set to true if using ntp < 4.2.8 or any unpatched ntp version to mitigate CVE-2014-9293 / CVE-2014-9294 / CVE-2014-9295
+
 ### Platform specific
 
 * `ntp['packages']`

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -56,6 +56,9 @@ default['ntp']['server']['use_burst'] = false
 default['ntp']['server']['minpoll'] = 6
 default['ntp']['server']['maxpoll'] = 10
 
+# Set to true if using ntp < 4.2.8 or any unpatched ntp version
+default['ntp']['localhost']['noquery'] = false
+
 # overrides on a platform-by-platform basis
 case node['platform_family']
 when 'debian'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -56,7 +56,7 @@ default['ntp']['server']['use_burst'] = false
 default['ntp']['server']['minpoll'] = 6
 default['ntp']['server']['maxpoll'] = 10
 
-# Set to true if using ntp < 4.2.8 or any unpatched ntp version
+# Set to true if using ntp < 4.2.8 or any unpatched ntp version to mitigate CVE-2014-9293 / CVE-2014-9294 / CVE-2014-9295
 default['ntp']['localhost']['noquery'] = false
 
 # overrides on a platform-by-platform basis

--- a/templates/default/ntp.conf.erb
+++ b/templates/default/ntp.conf.erb
@@ -68,9 +68,9 @@ disable monitor
 <% end -%>
 
 restrict default kod notrap nomodify nopeer noquery
-restrict 127.0.0.1 nomodify
+restrict 127.0.0.1 nomodify<%if node['ntp']['localhost']['noquery'] -%> noquery<% end -%>
 restrict -6 default kod notrap nomodify nopeer noquery
-restrict -6 ::1 nomodify
+restrict -6 ::1 nomodify<%if node['ntp']['localhost']['noquery'] -%> noquery<% end -%>
 
 <%# If this is a server with additional LAN restriction lines, put them here %>
 <% unless node['ntp']['restrictions'].empty? -%>


### PR DESCRIPTION
Provide a way to set the noquery option for restrict localhost lines, for working around the latest ntp security issue.

Details of the bug & mitigation is here: http://googleprojectzero.blogspot.nl/2015/01/finding-and-exploiting-ntpd.html