### PR TITLE
ntp.leapseconds notifies ntp service with a delayed restart

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -41,6 +41,7 @@ else
     group node['ntp']['conf_group']
     mode  '0644'
     source 'ntp.leapseconds'
+    notifies :restart, "service[#{node['ntp']['service']}]"
   end
 
   include_recipe 'ntp::apparmor' if node['ntp']['apparmor_enabled']

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -60,6 +60,12 @@ describe 'ntp::default' do
     it 'has 0644 permissions' do
       expect(cookbook_file.mode).to eq('0644')
     end
+
+    it 'notifies ntp service to restart' do
+      resource = chef_run.cookbook_file(chef_run.node['ntp']['leapfile'])
+      service = "service[#{chef_run.node['ntp']['service']}]"
+      expect(resource).to notify(service).to(:restart).delayed
+    end
   end
 
   context 'the ntp.conf' do


### PR DESCRIPTION
When a new ntp.leapseconds file is added, ntp is not restarted.  To pick up the change, ntp needs to be restarted.

Solves issue https://github.com/gmiranda23/ntp/issues/80