### PR TITLE
Add attr to allow conf to restart immediate

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Attributes
    `ntp['statsdir']`.
  - Not available on Windows.
 
+* `ntp['conf_restart_immediate']`
+  - Boolean. Defaults to false. Restarts NTP service immediately after a config update if true.  Otherwise it is a delayed restart.
+
 * `ntp['peer']['use_iburst']` (applies to NTP Servers ONLY)
   - Boolean. Defaults to true. Enables iburst in peer declaration.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -45,6 +45,7 @@ default['ntp']['listen_network'] = nil
 default['ntp']['apparmor_enabled'] = false
 default['ntp']['monitor'] = false
 default['ntp']['statistics'] = true
+default['ntp']['conf_restart_immediate'] = false
 
 default['ntp']['peer']['use_iburst'] = true
 default['ntp']['peer']['use_burst'] = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -79,7 +79,8 @@ template node['ntp']['conffile'] do
   owner    node['ntp']['conf_owner']
   group    node['ntp']['conf_group']
   mode     '0644'
-  notifies :restart, "service[#{node['ntp']['service']}]"
+  notifies :restart, "service[#{node['ntp']['service']}]" unless node['ntp']['conf_restart_immediate']
+  notifies :restart, "service[#{node['ntp']['service']}]", :immediately if node['ntp']['conf_restart_immediate']
   variables(
       :ntpd_supports_native_leapfiles => leapfile_enabled
   )

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -86,6 +86,10 @@ describe 'ntp attributes' do
       expect(ntp['monitor']).to eq(false)
     end
 
+    it 'sets conf_restart_immediate to false' do
+      expect(ntp['conf_restart_immediate']).to eq(false)
+    end
+
     it 'sets peer use_iburst to true' do
       expect(ntp['peer']['use_iburst']).to eq(true)
     end


### PR DESCRIPTION
Adds an attribute (`conf_restart_immediate`) to switch a config update from a delayed restart to an immediate restart.  This is useful when the cookbook is part of a long chef run and you want the NTP service to start working the way you want before the chef run is over.