### PR TITLE
Add preferred ntp server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Attributes
 * `ntp['peer']['maxpoll']` (applies to NTP Servers ONLY)
   - Boolean. Defaults to 10 (ntp default). Specify the maximum poll intervals for NTP messages, in seconds to the power of two.
 
+* `ntp['server']['prefer']` (applies to NTP Servers and Clients)
+  - String. No Default. The server from `ntp['servers']` to prefer getting the time from.
+
 * `ntp['server']['use_iburst']` (applies to NTP Servers and Clients)
   - Boolean. Defaults to true. Enables iburst in server declaration.
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Attributes
   - Boolean. Defaults to 10 (ntp default). Specify the maximum poll intervals for NTP messages, in seconds to the power of two.
 
 * `ntp['server']['prefer']` (applies to NTP Servers and Clients)
-  - String. No Default. The server from `ntp['servers']` to prefer getting the time from.
+  - String. Defaults to emtpy string. The server from `ntp['servers']` to prefer getting the time from.
 
 * `ntp['server']['use_iburst']` (applies to NTP Servers and Clients)
   - Boolean. Defaults to true. Enables iburst in server declaration.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -51,6 +51,7 @@ default['ntp']['peer']['use_burst'] = false
 default['ntp']['peer']['minpoll'] = 6
 default['ntp']['peer']['maxpoll'] = 10
 
+default['ntp']['server']['prefer'] = ''
 default['ntp']['server']['use_iburst'] = true
 default['ntp']['server']['use_burst'] = false
 default['ntp']['server']['minpoll'] = 6

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -102,6 +102,10 @@ describe 'ntp attributes' do
       expect(ntp['peer']['maxpoll']).to eq(10)
     end
 
+    it 'sets server prefer to empty string' do
+      expect(ntp['server']['prefer']).to eq('')
+    end
+
     it 'sets server use_iburst to true' do
       expect(ntp['server']['use_iburst']).to eq(true)
     end

--- a/templates/default/ntp.conf.erb
+++ b/templates/default/ntp.conf.erb
@@ -62,7 +62,7 @@ disable monitor
 <% ( node['ntp']['servers'] - node['ntp']['peers'] ).each do |ntpserver| -%>
 <%#   Loop through defined servers, but don't try to upstream ourself %>
 <%   if node['ipaddress'] != ntpserver and node['fqdn'] != ntpserver -%>
-<%  -%>server <%= ntpserver %><% if node['ntp']['server']['use_iburst'] -%> iburst<% end -%><% if node['ntp']['server']['use_burst'] -%> burst<% end -%> minpoll <%= node['ntp']['server']['minpoll'] %> maxpoll <%= node['ntp']['server']['maxpoll'] %>
+<%  -%>server <%= ntpserver %><% if node['ntp']['server']['use_iburst'] -%> iburst<% end -%><% if node['ntp']['server']['use_burst'] -%> burst<% end -%> minpoll <%= node['ntp']['server']['minpoll'] %> maxpoll <%= node['ntp']['server']['maxpoll'] %><% if node['ntp']['server']['prefer'] == ntpserver -%> prefer<% end -%>
 <%  -%>restrict <%= ntpserver %> nomodify notrap noquery
 <%   end -%>
 <% end -%>


### PR DESCRIPTION
Fixes #94

Adds a `['ntp']['server']['prefer']` attribute to set the preferred ntp server.  The value of this attribute should match an element in `['ntp']['servers']`

