### PR TITLE
bump test-kitchen gem version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.5
 bundler_args: --without integration

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ gem 'foodcritic', '~> 4.0'
 gem 'rubocop',    '~> 0.27.1'
 
 group :integration do
-  gem 'test-kitchen',    '~> 1.2.1'
+  gem 'test-kitchen',    '~> 1.3.1'
   gem 'kitchen-vagrant', '~> 0.15'
 end


### PR DESCRIPTION
There is a bug in test-kitchen v1.2.1 where it does not load properly

```
$ bundle exec kitchen list
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ClientError
>>>>>> Message: Could not load the 'vagrant' driver from the load path. Please ensure that your driver is installed as a gem or included in your Gemfile if using Bundler.
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
$
```

Partial kitchen.log excerpt:

```
E, [2015-04-11T00:37:24.363748 #1902] ERROR -- Kitchen: ----------------------
E, [2015-04-11T00:44:50.287731 #1941] ERROR -- Kitchen: ------Exception-------
E, [2015-04-11T00:44:50.288105 #1941] ERROR -- Kitchen: Class: Kitchen::ClientError
E, [2015-04-11T00:44:50.288153 #1941] ERROR -- Kitchen: Message: Could not load the 'vagrant' driver from the load path. Please ensure that your driver is installed as a gem or included in your Gemfile if using Bundler.
E, [2015-04-11T00:44:50.288169 #1941] ERROR -- Kitchen: ---Nested Exception---
E, [2015-04-11T00:44:50.288182 #1941] ERROR -- Kitchen: Class: NoMethodError
E, [2015-04-11T00:44:50.288194 #1941] ERROR -- Kitchen: Message: undefined method `expand_path_for' for Kitchen::Driver::Vagrant:Class
E, [2015-04-11T00:44:50.288206 #1941] ERROR -- Kitchen: ------Backtrace-------
E, [2015-04-11T00:44:50.288218 #1941] ERROR -- Kitchen: /Users/user/github/ntp/.bundle/ruby/2.1.0/gems/test-kitchen-1.2.1/lib/kitchen/driver.rb:50:in `rescue in for_plugin'
E, [2015-04-11T00:44:50.288248 #1941] ERROR -- Kitchen: /Users/user/github/ntp/.bundle/ruby/2.1.0/gems/test-kitchen-1.2.1/lib/kitchen/driver.rb:40:in `for_plugin'
E, [2015-04-11T00:44:50.288261 #1941] ERROR -- Kitchen: /Users/user/github/ntp/.bundle/ruby/2.1.0/gems/test-kitchen-1.2.1/lib/kitchen/config.rb:124:in `new_driver'
E, [2015-04-11T00:44:50.288273 #1941] ERROR -- Kitchen: /Users/user/github/ntp/.bundle/ruby/2.1.0/gems/test-kitchen-1.2.1/lib/kitchen/config.rb:130:in `new_instance'
E, [2015-04-11T00:44:50.288299 #1941] ERROR -- Kitchen: /Users/user/github/ntp/.bundle/ruby/2.1.0/gems/test-kitchen-1.2.1/lib/kitchen/config.rb:73:in `block in build_instances'
E, [2015-04-11T00:44:50.288313 #1941] ERROR -- Kitchen: /Users/user/github/ntp/.bundle/ruby/2.1.0/gems/test-kitchen-1.2.1/lib/kitchen/config.rb:72:in `map'
E, [2015-04-11T00:44:50.288325 #1941] ERROR -- Kitchen: /Users/user/github/ntp/.bundle/ruby/2.1.0/gems/test-kitchen-1.2.1/lib/kitchen/config.rb:72:in `with_index'
E, [2015-04-11T00:44:50.288355 #1941] ERROR -- Kitchen: /Users/user/github/ntp/.bundle/ruby/2.1.0/gems/test-kitchen-1.2.1/lib/kitchen/config.rb:72:in `build_instances'
E, [2015-04-11T00:44:50.288368 #1941] ERROR -- Kitchen: /Users/user/github/ntp/.bundle/ruby/2.1.0/gems/test-kitchen-1.2.1/lib/kitchen/config.rb:52:in `instances'
E, [2015-04-11T00:44:50.288379 #1941] ERROR -- Kitchen: /Users/user/github/ntp/.bundle/ruby/2.1.0/gems/test-kitchen-1.2.1/lib/kitchen/command.rb:64:in `get_filtered_instances'
E, [2015-04-11T00:44:50.288391 #1941] ERROR -- Kitchen: /Users/user/github/ntp/.bundle/ruby/2.1.0/gems/test-kitchen-1.2.1/lib/kitchen/command.rb:85:in `parse_subcommand'
E, [2015-04-11T00:44:50.288403 #1941] ERROR -- Kitchen: /Users/user/github/ntp/.bundle/ruby/2.1.0/gems/test-kitchen-1.2.1/lib/kitchen/command/list.rb:31:in `call'
E, [2015-04-11T00:44:50.288415 #1941] ERROR -- Kitchen: /Users/user/github/ntp/.bundle/ruby/2.1.0/gems/test-kitchen-1.2.1/lib/kitchen/cli.rb:47:in `perform'
E, [2015-04-11T00:44:50.288427 #1941] ERROR -- Kitchen: /Users/user/github/ntp/.bundle/ruby/2.1.0/gems/test-kitchen-1.2.1/lib/kitchen/cli.rb:81:in `list'
```