### PR TITLE
leapfile_enabled always false on 1st run, since set at compile time phase

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-::Chef::Recipe.send(:include, Opscode::Ntp::Helper)
+::Chef::Resource.send(:include, Opscode::Ntp::Helper)
 
 if platform_family?('windows')
   include_recipe 'ntp::windows_client'
@@ -73,7 +73,6 @@ if node['ntp']['listen'].nil? && !node['ntp']['listen_network'].nil?
   end
 end
 
-leapfile_enabled = ntpd_supports_native_leapfiles
 node.default['ntp']['tinker']['panic'] = 0 if node['virtualization'] &&
                                               node['virtualization']['role'] == 'guest' &&
                                               node['ntp']['disable_tinker_panic_on_virtualization_guest']
@@ -86,7 +85,9 @@ template node['ntp']['conffile'] do
   notifies :restart, "service[#{node['ntp']['service']}]" unless node['ntp']['conf_restart_immediate']
   notifies :restart, "service[#{node['ntp']['service']}]", :immediately if node['ntp']['conf_restart_immediate']
   variables(
-      :ntpd_supports_native_leapfiles => leapfile_enabled
+    lazy {
+      {:ntpd_supports_native_leapfiles => ntpd_supports_native_leapfiles}
+    }
   )
 end
 


### PR DESCRIPTION
Problem: It has always taken 2 chef runs in order to correctly configure NTP. This was due to the  leapfile_enabled variable in recipe::default ALWAYS being false. It was being set at compile_time and ntpd command isn't available till after the package resource is executed in the converge phase. Logging the exception revealed that fact:

       ---- Begin output of ntpd --version 2>&1 ----
       STDOUT: sh: ntpd: command not found
       STDERR:
       ---- End output of ntpd --version 2>&1 ----
       Ran ntpd --version 2>&1 returned 127

Simple fix though! Moved helper to be included in resource instead of recipe. Perform Lazy evaluation for the variable in the template resource to ensure it's not evaluated to converge phase.

This was the single last cookbook I use that required two runs. :smile: 