### PR TITLE
Fix missing DNS on boot issue

### DIFF
--- a/templates/default/ntp.conf.erb
+++ b/templates/default/ntp.conf.erb
@@ -68,9 +68,9 @@ disable monitor
 <% end -%>
 
 restrict default <%= node['ntp']['restrict_default'] %>
-restrict 127.0.0.1 nomodify<%if node['ntp']['localhost']['noquery'] -%> noquery<% end -%>
+restrict 127.0.0.1<%if node['ntp']['localhost']['noquery'] -%> noquery<% end -%>
 restrict -6 default <%= node['ntp']['restrict_default'] %>
-restrict -6 ::1 nomodify<%if node['ntp']['localhost']['noquery'] -%> noquery<% end -%>
+restrict -6 ::1<%if node['ntp']['localhost']['noquery'] -%> noquery<% end -%>
 
 <%# If this is a server with additional LAN restriction lines, put them here %>
 <% unless node['ntp']['restrictions'].empty? -%>


### PR DESCRIPTION
If ntpd starts on boot before DNS is available then it continually
reports "ntp_intres.request: permission denied" and ntpq -p fails with
"No association ID's returned". Debian bug #571469 explains that this
can be prevented by removing nomodify from the restrict localhost
lines. nomodify has not been present on these lines by default for
some time and I cannot see it on any of my systems not managed by
Chef.

In the wake of January's vulnerabilities, Project Zero recommended
that either nomodify or noquery be added to the restrict localhost
lines, at least for those who hadn't patched against the
vulnerabilities. The cookbook already offers the option to add noquery
so removing nomodify from the template should not be an issue.