### PR TITLE
Fix duplication of localhost listen directive in template

### DIFF
--- a/templates/default/ntp.conf.erb
+++ b/templates/default/ntp.conf.erb
@@ -35,7 +35,7 @@ interface listen <%= listen %>
 <%   end -%>
 <%#  The service must always listen on localhost %>
 <%   unless Array(node['ntp']['listen']).include? '127.0.0.1' -%>
- interface listen 127.0.0.1    interface listen 127.0.0.1
+interface listen 127.0.0.1
 <%   end -%>
 <% end -%>
 


### PR DESCRIPTION
Fix up the `interface` directive for localhost and remove the duplicated content from the line. While this does not cause any issues or prevent NTP from starting, it is a glaring mistake in the template.