### PR TITLE
Allow loopback client to modify ntp configuration

### DIFF
--- a/templates/default/ntp.conf.erb
+++ b/templates/default/ntp.conf.erb
@@ -68,9 +68,9 @@ disable monitor
 <% end -%>
 
 restrict default <%= node['ntp']['restrict_default'] %>
-restrict 127.0.0.1 nomodify<%if node['ntp']['localhost']['noquery'] -%> noquery<% end -%>
+restrict 127.0.0.1<%if node['ntp']['localhost']['noquery'] -%> noquery<% end -%>
 restrict -6 default <%= node['ntp']['restrict_default'] %>
-restrict -6 ::1 nomodify<%if node['ntp']['localhost']['noquery'] -%> noquery<% end -%>
+restrict -6 ::1<%if node['ntp']['localhost']['noquery'] -%> noquery<% end -%>
 
 <%# If this is a server with additional LAN restriction lines, put them here %>
 <% unless node['ntp']['restrictions'].empty? -%>


### PR DESCRIPTION
Consider a situation where the host runs a local nameserver like BIND or
a proxy like dnsmasq, and ntpd starts before the namserver or proxy
does.  This causes a race condition where ntpd may not be able to
resolve its configured nameserver addresses immediately.

The `nomodify` option added by the cookbook made it so that ntpd is
unable to self-heal - it will not attempt to re-resolve the hosts after
startup.  Removing this option is safe for the loopback interfaces as it
will not introduce a security risk -- and `nomodify` is explicitly
excluded from the loopback interface restriction set on both Ubuntu and
EL (Red Hat/CentOS) distributions.

See also https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=571469 for
additional background.