### PR TITLE
correct duplicated localhost listen in ntp.conf template

### DIFF
--- a/templates/default/ntp.conf.erb
+++ b/templates/default/ntp.conf.erb
@@ -35,7 +35,7 @@ interface listen <%= listen %>
 <%   end -%>
 <%#  The service must always listen on localhost %>
 <%   unless Array(node['ntp']['listen']).include? '127.0.0.1' -%>
- interface listen 127.0.0.1    interface listen 127.0.0.1
+interface listen 127.0.0.1
 <%   end -%>
 <% end -%>
 


### PR DESCRIPTION
Noticed that ntpd was complaining about a syntax issue in the logs. This didn't seem fatal, but had a look at the template and it looks like maybe a typo in vi resulted in a duplicate listen line for the localhost to be expressed.

Just removed the duplicity.