### PR TITLE
possible race condition

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,6 +28,11 @@ else
     package ntppkg
   end
 
+  service node['ntp']['service'] do
+    supports :status => true, :restart => true
+    action  :nothing
+  end
+
   [node['ntp']['varlibdir'], node['ntp']['statsdir']].each do |ntpdir|
     directory ntpdir do
       owner node['ntp']['var_owner']
@@ -109,7 +114,9 @@ execute 'Force sync hardware clock with system clock' do
   only_if { node['ntp']['sync_hw_clock'] && !platform_family?('windows') }
 end
 
-service node['ntp']['service'] do
-  supports :status => true, :restart => true
-  action   [:enable, :start]
+execute "placeholder" do
+    command '/bin/true'
+    action :run
+  notifies :enable, "service[#{node['ntp']['service']}]"
+  notifies :start, "service[#{node['ntp']['service']}]"
 end


### PR DESCRIPTION
Hello,

Here is a bug I have found, along with a solution.

Running the ntp cookbook with this attribute: node.default['ntp']['sync_clock'] = true

chef-client crashes, about 50% of the time.

Expected process to exit with [0], but received '1'
Begin output of ntpd -q ---- STDOUT: STDERR:
End output of ntpd -q ---- Ran ntpd -q returned 1

add the -d flag for debugging, and so it runs ntpd -q -d.   The result is:

unable to bind to wildcard address 0.0.0.0 - another process may be running - EXITING

In other words, the previous command to stop ntp had not completed yet.

change the recipe code from "ntpd -q" to "sleep 1; ntpd -q"

It works.  However that is not an ideal solution, to add a sleep.

Next, moved the service definition up to the top of the file, in case the ordering of service definitions matters:
 
service node['ntp']['service'] do
    supports :status => true, :restart => true
    action  :nothing
  end

And then call service :start at the end of the file.

This also works, and avoids the sleep.

The bug was only appearing on a slow vagrant virtual machine, but it was consistently happening.  After this change, it seems to be fixed.
