### PR TITLE
setting the `var_owner` on FreeBSD to root instead of default ntp

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -100,6 +100,7 @@ when 'freebsd'
   default['ntp']['driftfile'] = "#{node['ntp']['varlibdir']}/ntpd.drift"
   default['ntp']['statsdir'] = "#{node['ntp']['varlibdir']}/ntpstats"
   default['ntp']['conf_group'] = 'wheel'
+  default['ntp']['var_owner'] = 'root'
   default['ntp']['var_group'] = 'wheel'
 when 'gentoo'
   default['ntp']['packages'] = %w(ntp)

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -274,6 +274,10 @@ describe 'ntp attributes' do
       expect(ntp['conf_group']).to eq('wheel')
     end
 
+    it 'sets the var_owner to root' do
+      expect(ntp['var_owner']).to eq('root')
+    end
+
     it 'sets the var_group to wheel' do
       expect(ntp['var_group']).to eq('wheel')
     end


### PR DESCRIPTION
On FreeBSD the `var_owner` should be `root` as the `/var/db` is owned by `root:wheel` on FreeBSD.
Tested on FreeBSD 10.1.