### PR TITLE
update chefignore to a more standard version

### DIFF
--- a/chefignore
+++ b/chefignore
@@ -1,20 +1,96 @@
-# Put files/directories that should be ignored in this file.
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
 # Lines that start with '# ' are comments.
 
-# gitignore
-\.gitignore
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
 
-# emacs
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
 *~
-
-# vim
 *.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
 
-# subversion
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+Guardfile
+Procfile
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
 */.svn/*
 
-# tests
-*/test/*
-\.travis.yml
-Rakefile
-*/spec/*
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING
+CHANGELOG*
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+
+# Travis #
+##########
+.travis.yml


### PR DESCRIPTION
I was getting a test-kitchen error when trying to run the ntp cookbook (see below) - so I figured it was time for this cookbook to get a more updated standard chefignore file.

```
--- RESPONSE (404) ---
{
  "error": [
    "Object not found: chefzero://localhost:8889/file_store/repo/cookbooks/ntp/files/default/tests/minitest/Icon"
  ]
}
```